### PR TITLE
fix(endpoints): Add type annotation to endpoints array

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@murat/yelix",
   "exports": "./mod.ts",
-  "version": "0.1.44",
+  "version": "0.1.46",
   "license": "MIT",
   "nodeModulesDir": "auto",
   "tasks": {

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@murat/yelix",
-  "version": "0.1.44",
+  "version": "0.1.46",
   "license": "MIT",
   "exports": {
     ".": "./mod.ts",

--- a/src/core/HMR.ts
+++ b/src/core/HMR.ts
@@ -109,7 +109,8 @@ async function generateEndpointsFile(rootPath: string, outputPath: string) {
     }
   });
 
-  const endpointsContent = "const endpoints = [\n" +
+  const endpointsContent = "// deno-lint-ignore no-explicit-any" +
+    "const endpoints: any[] = [\n" +
     importStatements.join("") +
     "\n];\nexport default endpoints;\n";
 

--- a/testing/endpoints.ts
+++ b/testing/endpoints.ts
@@ -1,4 +1,5 @@
-const endpoints = [
+// deno-lint-ignore no-explicit-any
+const endpoints: any[] = [
   await import("./api/body.ts"),
   await import("./api/formData.ts"),
   await import("./api/hello.ts"),

--- a/version.ts
+++ b/version.ts
@@ -1,2 +1,2 @@
-const version = "0.1.44";
+const version = "0.1.46";
 export default version;


### PR DESCRIPTION
- Ignore no-explicit-any for deno-lint. We don't need strict types for endpoints array